### PR TITLE
Pools metadata improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7680,6 +7680,17 @@
         "ext": "^1.1.2"
       }
     },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "escalade": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
@@ -8657,6 +8668,15 @@
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
+      }
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -25339,6 +25359,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -26835,6 +26860,14 @@
         }
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
@@ -26933,6 +26966,28 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "dependencies": {
+        "next-tick": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
         }
       }
     },
@@ -32967,6 +33022,15 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
       }
     },
     "timsort": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "i18next": "^19.6.3",
     "i18next-browser-languagedetector": "^4.3.1",
     "ipfs-react-router": "^0.2.2",
+    "memoizee": "^0.4.15",
     "moment": "^2.27.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import {
   Typography
 } from '@material-ui/core';
-import { withRouter } from "react-router-dom";
+import { withRouter } from 'react-router-dom';
 import { colors } from '../../theme'
 
 import {

--- a/src/components/liquidity/liquidity.jsx
+++ b/src/components/liquidity/liquidity.jsx
@@ -472,7 +472,7 @@ class Liquidity extends Component {
             />
           </div>
           <div className={ classes.assetSelectIconName }>
-            <Typography variant='h4'>{ option.symbol }</Typography>
+            <Typography variant='h4'>{ option.name }</Typography>
           </div>
         </React.Fragment>
       </MenuItem>

--- a/src/components/liquidity/liquidity.jsx
+++ b/src/components/liquidity/liquidity.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
 import { withStyles } from '@material-ui/core/styles';
+import PoolSeedingCTA from '../poolSeedingCTA'
 import {
   Typography,
   TextField,
@@ -183,7 +184,15 @@ class Liquidity extends Component {
 
     const account = store.getStore('account')
     const pools = store.getStore('pools')
-    const selectedPool = pools && pools.length > 0 ? pools[0] : null
+
+    const preSelectedPoolMatches = window.location.hash.match(/pool=([a-z0-9/-]+)/i);
+    const preSelectedPool = preSelectedPoolMatches === null ? null : preSelectedPoolMatches[1];
+
+    const selectedPool = (
+      !pools || pools.length === 0 ? null :
+      preSelectedPool !== null ? pools.find(({ id }) => id === preSelectedPool) :
+      pools[0]
+    );
 
     this.state = {
       account: account,
@@ -225,41 +234,53 @@ class Liquidity extends Component {
   configureReturned = () => {
     const pools = store.getStore('pools')
     const selectedPool = pools && pools.length > 0 ? pools[0] : null
-
-    this.setState({
+    const newStateSlice = {
       account: store.getStore('account'),
       pools: pools,
       pool: selectedPool ? selectedPool.symbol : '',
-      selectedPool: selectedPool,
+      selectedPool,
       loading: false,
-    })
+      ...this.getStateSliceUserBalancesForSelectedPool(selectedPool),
+    };
 
-    const val = []
+    this.setState(newStateSlice);
 
-    if(!selectedPool) {
-      return
-    }
+    if (!selectedPool) return;
 
-    for(let i = 0; i < selectedPool.assets.length; i++) {
-      val[selectedPool.assets[i].symbol+'Amount'] = selectedPool.assets[i].balance.toFixed(selectedPool.assets[i].decimals)
-    }
-
-    this.setState(val)
-
-    let that = this
-
-    // Note: This hardcoded delay doesn't seem to be causing issues, but let's hook things
-    // together more sturdily if it turns out it does
-    window.setTimeout(() => {
-      let amounts = []
-
-      for(let i = 0; i < selectedPool.assets.length; i++) {
-        amounts.push(that.state[selectedPool.assets[i].symbol+'Amount'])
-      }
-
-      dispatcher.dispatch({ type: GET_DEPOSIT_AMOUNT, content: { pool: selectedPool, amounts: amounts }})
-    }, 300)
+    this.getDepositAmount(newStateSlice);
   };
+
+  // Returns hash map of user balances for selected pool, e.g. { BACAmount: '2.00', USDTAmount: '3.00', … }
+  getStateSliceUserBalancesForSelectedPool = (selectedPool) => {
+    if (!selectedPool) return {}
+
+    // Todo: don't use tofixed() anymore, it rounds up and might lead to failed txs
+    return Object.assign({}, ...selectedPool.assets.map(({ symbol, balance, decimals }) => ({
+      [`${symbol}Amount`]: balance.toFixed(decimals)
+    })))
+  }
+
+  getDepositAmount = (newStateSlice = {}) => {
+    const futureState = {
+      ...this.state,
+      ...newStateSlice,
+    };
+
+    const { selectedPool } = futureState;
+    if (!selectedPool) return;
+
+    this.setState({
+      depositAmount: '',
+    });
+
+    if (!selectedPool.isPoolSeeded) return;
+
+    const amounts = selectedPool.assets
+      .map(({ symbol }) => futureState[`${symbol}Amount`]) // Gather balances for that pool from state
+      .map((amount) => (amount === '' || isNaN(amount)) ? 0 : amount) // Sanitize
+
+    dispatcher.dispatch({ type: GET_DEPOSIT_AMOUNT, content: { pool: selectedPool, amounts }})
+  }
 
   getDepositAmountReturned = (val) => {
     console.log(val)
@@ -347,7 +368,7 @@ class Liquidity extends Component {
             <Typography variant='h4'>pool</Typography>
           </div>
           <div className={ classes.balances }>
-            { (selectedPool ? (<Typography variant='h4' onClick={ () => { this.setAmount(selectedPool.symbol, 'pool', (selectedPool ? selectedPool.balance.toFixed(selectedPool.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( selectedPool && selectedPool.balance ? (Math.floor(selectedPool.balance*10000)/10000).toFixed(4) : '0.0000') } { selectedPool ? selectedPool.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
+            { (selectedPool ? (<Typography variant='h4' onClick={ () => { this.setAmount('pool', (selectedPool ? selectedPool.balance.toFixed(selectedPool.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( selectedPool && selectedPool.balance ? (Math.floor(selectedPool.balance*10000)/10000).toFixed(4) : '0.0000') } { selectedPool ? selectedPool.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
           </div>
         </div>
         <div>
@@ -491,6 +512,8 @@ class Liquidity extends Component {
     return (
       <React.Fragment>
         { this.renderPoolSelect() }
+        {(selectedPool && !selectedPool.isPoolSeeded) &&
+          <PoolSeedingCTA pool={selectedPool} isDepositForm />}
         <div className={ classes.space }></div>
         {
           selectedPool && selectedPool.assets && selectedPool.assets.length > 0 && selectedPool.assets.map((p) => {
@@ -523,6 +546,8 @@ class Liquidity extends Component {
       slippagePcent,
       selectedPool
     } = this.state
+
+    if (selectedPool && !selectedPool.isPoolSeeded) return null;
 
     return (
       <div className={ classes.valContainer }>
@@ -614,7 +639,7 @@ class Liquidity extends Component {
             </Typography>
           </div>
           <div className={ classes.balances }>
-            { (asset ? (<Typography variant='h4' onClick={ () => { if(DorW === 'withdraw') { return false; } this.setAmount(asset.id, type, (asset ? asset.balance.toFixed(asset.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( asset && asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset ? asset.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
+            { (asset ? (<Typography variant='h4' onClick={ () => { if(DorW === 'withdraw') { return false; } this.setAmount(type, (asset ? asset.balance.toFixed(asset.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( asset && asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset ? asset.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
           </div>
         </div>
         <div>
@@ -653,78 +678,42 @@ class Liquidity extends Component {
   }
 
   onPoolSelectChange = (event) => {
-    const thePool = this.state.pools.filter((pool) => {
+    const selectedPool = this.state.pools.find((pool) => {
       return pool.id === event.target.value
     })
 
-    const val = []
-    val[event.target.name] = event.target.value
-    val['selectedPool'] = thePool[0]
-    val[thePool[0].assets[0].symbol+'Amount'] = thePool[0].assets[0].balance.toFixed(thePool[0].assets[0].decimals)
-    val[thePool[0].assets[1].symbol+'Amount'] = thePool[0].assets[1].balance.toFixed(thePool[0].assets[1].decimals)
-    this.setState(val)
+    const newStateSlice = {
+      [event.target.name]: event.target.value,
+      selectedPool,
+      ...this.getStateSliceUserBalancesForSelectedPool(selectedPool),
+    };
 
-    this.setState(val)
+    this.setState(newStateSlice);
+    this.getDepositAmount(newStateSlice);
+
+    // If an url fragment was used to auto-select a pool, remove that
+    // fragment when we change pool to revert to the naked /liquidity url.
+    if (this.props.history.location.hash !== '') {
+      this.props.history.replace('/liquidity');
+    }
   }
 
   onChange = (event) => {
-    let val = []
-    val[event.target.id] = event.target.value
-    this.setState(val)
-
-    const {
-      selectedPool
-    } = this.state
-
-    let amounts = []
-
-    for(let i = 0; i < selectedPool.assets.length; i++) {
-
-      let am = '0'
-      if(event.target.id === selectedPool.assets[i].symbol+'Amount') {
-        am = event.target.value
-      } else {
-        am = this.state[selectedPool.assets[i].symbol+'Amount']
-      }
-
-      if(am !== '' && !isNaN(am)) {
-        amounts.push(am)
-      } else {
-        amounts.push('0')
-      }
+    const newStateSlice = {
+      [event.target.id]: event.target.value
     }
 
-    dispatcher.dispatch({ type: GET_DEPOSIT_AMOUNT, content: { pool: selectedPool, amounts: amounts }})
+    this.setState(newStateSlice);
+    this.getDepositAmount(newStateSlice);
   }
 
-  setAmount = (id, type, balance) => {
-    let val = []
-    val[type+"Amount"] = balance
-    this.setState(val)
+  setAmount = (symbol, balance) => {
+    const newStateSlice = {
+      [`${symbol}Amount`]: balance,
+    };
 
-    const {
-      selectedPool
-    } = this.state
-
-    let amounts = []
-
-    for(let i = 0; i < selectedPool.assets.length; i++) {
-
-      let am = '0'
-      if(type+"Amount" === selectedPool.assets[i].symbol+'Amount') {
-        am = balance
-      } else {
-        am = this.state[selectedPool.assets[i].symbol+'Amount']
-      }
-
-      if(am !== '' && !isNaN(am)) {
-        amounts.push(am)
-      } else {
-        amounts.push('0')
-      }
-    }
-
-    dispatcher.dispatch({ type: GET_DEPOSIT_AMOUNT, content: { pool: selectedPool, amounts: amounts }})
+    this.setState(newStateSlice);
+    this.getDepositAmount(newStateSlice);
   }
 
   toggleDeposit = () => {

--- a/src/components/liquidity/liquidity.jsx
+++ b/src/components/liquidity/liquidity.jsx
@@ -12,6 +12,7 @@ import { colors } from '../../theme'
 
 import Loader from '../loader'
 import SlippageInfo from '../slippageInfo'
+import { floatToFixed } from '../../utils/numbers'
 
 import {
   ERROR,
@@ -254,9 +255,8 @@ class Liquidity extends Component {
   getStateSliceUserBalancesForSelectedPool = (selectedPool) => {
     if (!selectedPool) return {}
 
-    // Todo: don't use tofixed() anymore, it rounds up and might lead to failed txs
     return Object.assign({}, ...selectedPool.assets.map(({ symbol, balance, decimals }) => ({
-      [`${symbol}Amount`]: balance.toFixed(decimals)
+      [`${symbol}Amount`]: floatToFixed(balance, decimals)
     })))
   }
 
@@ -368,7 +368,7 @@ class Liquidity extends Component {
             <Typography variant='h4'>pool</Typography>
           </div>
           <div className={ classes.balances }>
-            { (selectedPool ? (<Typography variant='h4' onClick={ () => { this.setAmount('pool', (selectedPool ? selectedPool.balance.toFixed(selectedPool.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( selectedPool && selectedPool.balance ? (Math.floor(selectedPool.balance*10000)/10000).toFixed(4) : '0.0000') } { selectedPool ? selectedPool.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
+            { (selectedPool ? (<Typography variant='h4' onClick={ () => { this.setAmount('pool', (selectedPool ? floatToFixed(selectedPool.balance, selectedPool.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( selectedPool && selectedPool.balance ? floatToFixed(selectedPool.balance, 4) : '0.0000') } { selectedPool ? selectedPool.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
           </div>
         </div>
         <div>
@@ -639,7 +639,7 @@ class Liquidity extends Component {
             </Typography>
           </div>
           <div className={ classes.balances }>
-            { (asset ? (<Typography variant='h4' onClick={ () => { if(DorW === 'withdraw') { return false; } this.setAmount(type, (asset ? asset.balance.toFixed(asset.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( asset && asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset ? asset.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
+            { (asset ? (<Typography variant='h4' onClick={ () => { if(DorW === 'withdraw') { return false; } this.setAmount(type, (asset ? floatToFixed(asset.balance, asset.decimals) : '0')) } } className={ classes.value } noWrap>{ ''+ ( asset && asset.balance ? floatToFixed(asset.balance, 4) : '0.0000') } { asset ? asset.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
           </div>
         </div>
         <div>
@@ -730,8 +730,8 @@ class Liquidity extends Component {
     }
 
     const val = []
-    val[selectedPool.assets[0].symbol+'Amount'] = selectedPool.assets[0].balance.toFixed(selectedPool.assets[0].decimals)
-    val[selectedPool.assets[1].symbol+'Amount'] = selectedPool.assets[1].balance.toFixed(selectedPool.assets[1].decimals)
+    val[selectedPool.assets[0].symbol+'Amount'] = floatToFixed(selectedPool.assets[0].balance, selectedPool.assets[0].decimals)
+    val[selectedPool.assets[1].symbol+'Amount'] = floatToFixed(selectedPool.assets[1].balance, selectedPool.assets[1].decimals)
     this.setState(val)
   }
 

--- a/src/components/poolSeedingCTA/package.json
+++ b/src/components/poolSeedingCTA/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "poolSeedingCTA.jsx"
+}

--- a/src/components/poolSeedingCTA/poolSeedingCTA.jsx
+++ b/src/components/poolSeedingCTA/poolSeedingCTA.jsx
@@ -24,7 +24,7 @@ const DepositPageLink = ({ pool, classes }) => {
   const history = useHistory();
 
   return (
-    <span onClick={() => history.push(`/liquidity#pool=${pool.id}`)} className={classes.link}>Seed pool yoursel</span>
+    <span onClick={() => history.push(`/liquidity#pool=${pool.id}`)} className={classes.link}>Seed pool yourself</span>
   );
 };
 

--- a/src/components/poolSeedingCTA/poolSeedingCTA.jsx
+++ b/src/components/poolSeedingCTA/poolSeedingCTA.jsx
@@ -1,0 +1,68 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { Alert } from '@material-ui/lab'
+import { withStyles } from '@material-ui/core/styles'
+import { useHistory } from 'react-router-dom'
+
+const styles = () => ({
+  alert: {
+    maxWidth: '438px',
+    margin: '0 auto',
+  },
+  link: {
+    color: 'inherit',
+    textDecoration: 'underline',
+    cursor: 'pointer',
+  },
+});
+
+const AssetLink = ({ erc20address, symbol, classes }) => (
+  <a href={`https://etherscan.io/token/${erc20address}`} target="_blank" rel="noopener noreferrer" className={classes.link}>{symbol}</a>
+);
+
+const DepositPageLink = ({ pool, classes }) => {
+  const history = useHistory();
+
+  return (
+    <span onClick={() => history.push(`/liquidity#pool=${pool.id}`)} className={classes.link}>Seed pool yoursel</span>
+  );
+};
+
+const PoolSeedingCTA = ({
+  classes,
+  pool,
+  isDepositForm,
+}) => {
+  const poolContainsUnexpectedAssetsCount = pool.assets.length < 2;
+  if (poolContainsUnexpectedAssetsCount) return null;
+
+  const firstAsset = pool.assets[0];
+  const metaPoolAssets = pool.assets.slice(1);
+
+  return (
+    <Alert icon={false} color="warning" className={classes.alert}>
+      This pool is still empty. It needs to be seeded with an initial deposit in order to enable swaps.
+      {isDepositForm ? (
+        <Fragment>
+          <br />Assuming an exchange rate of 1:1, this pool should be seeded with 50% <AssetLink {...firstAsset} classes={classes} />, and 50% {metaPoolAssets.map((asset) => <AssetLink {...asset} classes={classes} />).reduce((a, b) => [a, '+', b])}.
+        </Fragment>
+      ) : (
+        <Fragment>
+          <br /><DepositPageLink pool={pool} classes={classes} />
+        </Fragment>
+      )}
+    </Alert>
+  )
+}
+
+PoolSeedingCTA.propTypes = {
+  classes: PropTypes.object.isRequired,
+  pool: PropTypes.object.isRequired,
+  isDepositForm: PropTypes.bool,
+}
+
+PoolSeedingCTA.defaultProps = {
+  isDepositForm: false,
+}
+
+export default withStyles(styles)(PoolSeedingCTA);

--- a/src/components/rateInfo/rateInfo.jsx
+++ b/src/components/rateInfo/rateInfo.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Alert } from '@material-ui/lab'
 import { withStyles } from '@material-ui/core/styles';
 import { colors } from '../../theme'
+import { floatToFixed } from '../../utils/numbers'
 
 const styles = () => ({
   infoAlert: {
@@ -30,7 +31,7 @@ const RateInfo = ({
 
   return (
     <Alert icon={false} className={classes.infoAlert}>
-      Exchange rate {fromAsset}/{toAsset} (including fees): <strong>{Number(receivePerSend).toFixed(4)}</strong>
+      Exchange rate {fromAsset}/{toAsset} (including fees): <strong>{floatToFixed(receivePerSend, 4)}</strong>
     </Alert>
   )
 }

--- a/src/components/swap/swap.jsx
+++ b/src/components/swap/swap.jsx
@@ -13,6 +13,7 @@ import Loader from '../loader'
 import RateInfo from '../rateInfo'
 import UnderlyingAssetsInfo from './underlyingAssetsInfo'
 import PoolSeedingCTA from '../poolSeedingCTA'
+import { floatToFixed } from '../../utils/numbers'
 
 import {
   ERROR,
@@ -443,7 +444,7 @@ class Swap extends Component {
             <Typography variant='h4'>{ type }</Typography>
           </div>
           <div className={ classes.balances }>
-            { (asset ? (<Typography variant='h4' onClick={ () => { this.setAmount(asset.symbol, type, (asset ? asset.balance.toFixed(asset.decimals) : '0')) } } className={ classes.value } noWrap>{ 'Balance: '+ ( asset && asset.balance ? (Math.floor(asset.balance*10000)/10000).toFixed(4) : '0.0000') } { asset ? asset.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
+            { (asset ? (<Typography variant='h4' onClick={ () => { this.setAmount(asset.symbol, type, (asset ? floatToFixed(asset.balance, asset.decimals) : '0')) } } className={ classes.value } noWrap>{ 'Balance: '+ ( asset && asset.balance ? floatToFixed(asset.balance, 4) : '0.0000') } { asset ? asset.symbol : '' }</Typography>) : <Typography variant='h4' className={ classes.value } noWrap>Balance: -</Typography>) }
           </div>
         </div>
         <div>

--- a/src/components/swap/swap.jsx
+++ b/src/components/swap/swap.jsx
@@ -11,6 +11,7 @@ import { colors } from '../../theme'
 
 import Loader from '../loader'
 import RateInfo from '../rateInfo'
+import UnderlyingAssetsInfo from './underlyingAssetsInfo'
 
 import {
   ERROR,
@@ -346,7 +347,7 @@ class Swap extends Component {
   };
 
   renderPoolSelect = () => {
-    const { loading, pools, pool } = this.state
+    const { loading, pools, pool, selectedPool } = this.state
     const { classes } = this.props
 
     return (
@@ -384,6 +385,7 @@ class Swap extends Component {
             { pools ? pools.map((pool) => { return this.renderPoolOption(pool) }) : null }
           </TextField>
         </div>
+        <UnderlyingAssetsInfo selectedPool={selectedPool} />
       </div>
     )
   }

--- a/src/components/swap/underlyingAssetsInfo.jsx
+++ b/src/components/swap/underlyingAssetsInfo.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import { colors } from '../../theme'
+
+const styles = () => ({
+  info: {
+    paddingLeft: '12px',
+  },
+  link: {
+    color: colors.text,
+  },
+});
+
+const UnderlyingAssetsInfo = ({
+  selectedPool,
+  classes,
+}) => {
+  if (!selectedPool) return null;
+
+  const poolContainsUnexpectedAssetsCount = selectedPool.assets.length < 2;
+  if (poolContainsUnexpectedAssetsCount) return null;
+
+  const firstAsset = selectedPool.assets[0];
+  const metaPoolAssets = selectedPool.assets.slice(1);
+
+  return (
+    <div className={classes.info}>
+      Swap between{' '}
+      <a href={`https://etherscan.io/address/${firstAsset.erc20address}`} target="_blank" rel="noopener noreferrer" className={classes.link}>{firstAsset.symbol}</a>/
+      {metaPoolAssets.map(({ symbol }) => symbol).join('/')}
+    </div>
+  )
+}
+
+UnderlyingAssetsInfo.propTypes = {
+  classes: PropTypes.object.isRequired,
+}
+
+export default withStyles(styles)(UnderlyingAssetsInfo);

--- a/src/components/swap/underlyingAssetsInfo.jsx
+++ b/src/components/swap/underlyingAssetsInfo.jsx
@@ -27,7 +27,7 @@ const UnderlyingAssetsInfo = ({
   return (
     <div className={classes.info}>
       Swap between{' '}
-      <a href={`https://etherscan.io/address/${firstAsset.erc20address}`} target="_blank" rel="noopener noreferrer" className={classes.link}>{firstAsset.symbol}</a>/
+      <a href={`https://etherscan.io/token/${firstAsset.erc20address}`} target="_blank" rel="noopener noreferrer" className={classes.link}>{firstAsset.symbol}</a>/
       {metaPoolAssets.map(({ symbol }) => symbol).join('/')}
     </div>
   )

--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -343,6 +343,9 @@ class Store {
         .toFixed(decimals, BigNumber.ROUND_DOWN)
 
       const curveFactoryContract = new web3.eth.Contract(config.curveFactoryABI, config.curveFactoryAddress)
+      const poolBalances = await curveFactoryContract.methods.get_balances(pool).call()
+      const isPoolSeeded = sumArray(poolBalances) !== 0
+
       let coins = await curveFactoryContract.methods.get_underlying_coins(pool).call()
 
       let filteredCoins = coins.filter((coin) => {
@@ -418,6 +421,7 @@ class Store {
           decimals: decimals,
           name: name,
           balance: parseFloat(balance),
+          isPoolSeeded,
           id: symbol,
           assets: assets
         })

--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -1,5 +1,6 @@
 import config from '../config'
 import async from 'async'
+import memoize from 'memoizee'
 import BigNumber from 'bignumber.js'
 import { bnToFixed, multiplyBnToFixed, sumArray } from '../utils/numbers'
 
@@ -326,6 +327,34 @@ class Store {
     return emitter.emit(BALANCES_RETURNED)
   }
 
+  _getCoinData = memoize(async ({ web3, filteredCoins, coinAddress, accountAddress }) => {
+    const erc20Contract0 = new web3.eth.Contract(config.erc20ABI, coinAddress)
+
+    const symbol0 = await erc20Contract0.methods.symbol().call()
+    const decimals0 = parseInt(await erc20Contract0.methods.decimals().call())
+    const name0 = await erc20Contract0.methods.name().call()
+
+    let balance0 = await erc20Contract0.methods.balanceOf(accountAddress).call()
+    const bnDecimals0 = new BigNumber(10)
+      .pow(decimals0)
+
+    balance0 = new BigNumber(balance0)
+      .dividedBy(bnDecimals0)
+      .toFixed(decimals0, BigNumber.ROUND_DOWN)
+
+    return {
+      index: filteredCoins.indexOf(coinAddress),
+      erc20address: coinAddress,
+      symbol: symbol0,
+      decimals: decimals0,
+      name: name0,
+      balance: parseFloat(balance0)
+    }
+  }, {
+    promise: true,
+    normalizer: ([{ coinAddress, accountAddress }]) => `${coinAddress}-${accountAddress}`,
+  })
+
   _getPoolData = async (web3, pool, account, callback) => {
     try {
       const erc20Contract = new web3.eth.Contract(config.erc20ABI, pool)
@@ -354,28 +383,12 @@ class Store {
 
       async.map(filteredCoins, async (coin, callbackInner) => {
         try {
-          const erc20Contract0 = new web3.eth.Contract(config.erc20ABI, coin)
-
-          const symbol0 = await erc20Contract0.methods.symbol().call()
-          const decimals0 = parseInt(await erc20Contract0.methods.decimals().call())
-          const name0 = await erc20Contract0.methods.name().call()
-
-          let balance0 = await erc20Contract0.methods.balanceOf(account.address).call()
-          const bnDecimals0 = new BigNumber(10)
-            .pow(decimals0)
-
-          balance0 = new BigNumber(balance0)
-            .dividedBy(bnDecimals0)
-            .toFixed(decimals0, BigNumber.ROUND_DOWN)
-
-          const returnCoin = {
-            index: filteredCoins.indexOf(coin),
-            erc20address: coin,
-            symbol: symbol0,
-            decimals: decimals0,
-            name: name0,
-            balance: parseFloat(balance0)
-          }
+          const returnCoin = await this._getCoinData({
+            web3,
+            filteredCoins,
+            coinAddress: coin,
+            accountAddress: account.address,
+          });
 
           if(callbackInner) {
             callbackInner(null, returnCoin)

--- a/src/theme/theme.jsx
+++ b/src/theme/theme.jsx
@@ -122,6 +122,9 @@ const iswapTheme =  {
     },
     MuiSelect: {
       select: {
+        "&:focus": {
+          borderRadius: '50px'
+        },
         padding: '9px'
       },
       selectMenu: {

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -8,6 +8,10 @@ const bnToFixed = (bn, decimals, displayDecimals = decimals) => {
     .toFixed(displayDecimals, BigNumber.ROUND_DOWN)
 };
 
+const floatToFixed = (float, decimals = 0) => (
+  new BigNumber(float).toFixed(decimals, BigNumber.ROUND_DOWN)
+);
+
 // multiplyBnToFixed(bigNumber1, bigNumber2[, bigNumberN], decimals)
 const multiplyBnToFixed = (...args) => {
   if (args.length < 3) throw new Error('multiplyBnToFixed needs at least 3 arguments: first bn, second bn to multiply with first, and number of decimals.')

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -32,4 +32,5 @@ export {
   multiplyArray,
   sumArray,
   sumArrayBn,
+  floatToFixed,
 }

--- a/src/utils/numbers.test.js
+++ b/src/utils/numbers.test.js
@@ -1,0 +1,14 @@
+import {
+  floatToFixed,
+} from './numbers';
+
+it('floatToFixed()', () => {
+  expect(floatToFixed(1.23456)).toEqual('1');
+  expect(floatToFixed(1.23456, 1)).toEqual('1.2');
+  expect(floatToFixed(1.23456, 2)).toEqual('1.23');
+  expect(floatToFixed(1.23456, 4)).toEqual('1.2345');
+  expect(floatToFixed(12)).toEqual('12');
+  expect(floatToFixed(12, 2)).toEqual('12.00');
+  expect(floatToFixed(12.00)).toEqual('12');
+  expect(floatToFixed(0.0000000000005, 5)).toEqual('0.00000');
+});

--- a/src/utils/pools.js
+++ b/src/utils/pools.js
@@ -1,0 +1,31 @@
+import BigNumber from 'bignumber.js'
+
+const bnToFixed = (bn, decimals, displayDecimals = decimals) => {
+  const bnDecimals = new BigNumber(10).pow(decimals)
+
+  return new BigNumber(bn)
+    .dividedBy(bnDecimals)
+    .toFixed(displayDecimals, BigNumber.ROUND_DOWN)
+};
+
+// multiplyBnToFixed(bigNumber1, bigNumber2[, bigNumberN], decimals)
+const multiplyBnToFixed = (...args) => {
+  if (args.length < 3) throw new Error('multiplyBnToFixed needs at least 3 arguments: first bn, second bn to multiply with first, and number of decimals.')
+
+  const decimals = args[args.length - 1]
+  const bigNumbers = args.slice(0, -1)
+
+  return bnToFixed(multiplyArray(bigNumbers), decimals * bigNumbers.length, decimals)
+};
+
+const multiplyArray = (numbers) => numbers.reduce((total, n) => total * n, 1)
+const sumArray = (numbers) => numbers.reduce((total, n) => total + Number(n), 0)
+const sumArrayBn = (bigNumbers) => BigNumber.sum.apply(null, bigNumbers)
+
+export {
+  bnToFixed,
+  multiplyBnToFixed,
+  multiplyArray,
+  sumArray,
+  sumArrayBn,
+}


### PR DESCRIPTION
- Show pool names (instead of symbols) in the pool selector on Liquidity page, to make this more easily readable
- Add info about assets contained in a pool + link to Etherscan for the custom token to make it clear what you're swapping
  <img src="https://user-images.githubusercontent.com/2307365/107075156-0511e880-67ea-11eb-89ab-5fb48222312c.png" width="400" />
- Detect pools that need seeding, and invite to seed them
  <img src="https://user-images.githubusercontent.com/2307365/109576895-e5be6080-7af4-11eb-9758-0116ff6e251c.png" width="400" />
- Number precision tweak to prevent failed txs